### PR TITLE
pkcon priority

### DIFF
--- a/pkg
+++ b/pkg
@@ -100,8 +100,8 @@ upgrade() {
     case "$PKG_MAN" in
         pacman) $SUDO pacman -Syu "$@" ;;
         xbps) $SUDO xbps-install -Su "$@" ;;
-        apt) $SUDO apt update && apt upgrade "$@" ;;
-        pkcon) $SUDO pkcon refresh && pkcon update "$@" ;;
+        apt) $SUDO apt update && $SUDO apt upgrade "$@" ;;
+        pkcon) $SUDO pkcon update "$@" ;;
     esac
 }
 

--- a/pkg
+++ b/pkg
@@ -114,10 +114,10 @@ if command -v pacman >/dev/null; then
     PKG_MAN="pacman"
 elif command -v xbps-install >/dev/null; then
     PKG_MAN="xbps"
-elif command -v apt >/dev/null; then
-    PKG_MAN="apt"
 elif command -v pkcon >/dev/null; then
     PKG_MAN="pkcon"
+elif command -v apt >/dev/null; then
+    PKG_MAN="apt"
 else
     echo "Unsupported package manager." >&2
 fi


### PR DESCRIPTION
Testing for pkgcon first is needed to ensure it is used on kde neon. Also, the `pkgcon refresh` command is not really needed for upgrades.
Furthermore, `apt upgrade` was missing sudo, so I added that too. Otherwise, it will just open a gui popup window to ask for password